### PR TITLE
ci: add spell check job using cspell-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,19 @@ env:
   SAST_BRANCH: main
 
 jobs:
+  spell-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Spell check
+        uses: streetsidesoftware/cspell-action@v6
+        with:
+          files: "**/*.md"
+          strict: false
+
   static-check:
     runs-on: S60
     


### PR DESCRIPTION
## Summary

Add a `spell-check` CI job to `.github/workflows/ci.yml` that runs on every push/PR to `main`.

- Uses `streetsidesoftware/cspell-action@v6` to check spelling in all `**/*.md` files
- Runs on `ubuntu-latest` independently of the existing `static-check` job
- `strict: false` — reports issues without blocking merges (can be tightened later)